### PR TITLE
gitconfigの設定

### DIFF
--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -1,3 +1,20 @@
+[core]
+    editor = 'vim -c "set fenc=utf-8"'
+    precomposeunicode = true
+    quotepath = false
+
+[color]
+    ui = auto
+    status = auto
+    diff = auto
+    branch = auto
+    interactive = auto
+    grep = auto
+
+[push]
+    # nothing, matching, upstream, simple(default), current
+    default = upstream
+
 [include]
     path = ~/.gitconfig_local
 


### PR DESCRIPTION
### 該当
- editorをvimに設定
- unicode関連の設定
- color関連の設定(auto)
- push.defaultの設定(upstream)
